### PR TITLE
sensor.py

### DIFF
--- a/custom_components/carddav_birthdays/sensor.py
+++ b/custom_components/carddav_birthdays/sensor.py
@@ -106,11 +106,19 @@ class CardDavBirthdaySensor(CoordinatorEntity, SensorEntity):
         try:
             # birthday string format depends on vobject.
             # Usually YYYY-MM-DD. Sometimes --MM-DD (no year).
+            # Also support YYYYMMDD (8 digits without dashes).
             bday_str = str(self.contact.birthday)
             today = date.today()
             
+            # Handle YYYYMMDD (8 digits without dashes)
+            if len(bday_str) == 8 and bday_str.isdigit():
+                try:
+                    bday = datetime.strptime(bday_str, "%Y%m%d").date()
+                    has_year = True
+                except ValueError:
+                    return None, None
             # Handle YYYY-MM-DD
-            if len(bday_str) >= 10:
+            elif len(bday_str) >= 10:
                 # Naive parsing
                 # Some vCards use T timestamp, split at T
                 bday_date_part = bday_str.split('T')[0]
@@ -198,7 +206,12 @@ class CardDavNextBirthdaySensor(CoordinatorEntity, SensorEntity):
             try:
                 bday_str = str(contact.birthday)
                 
-                if len(bday_str) >= 10:
+                # Handle YYYYMMDD (8 digits without dashes)
+                if len(bday_str) == 8 and bday_str.isdigit():
+                    bday = datetime.strptime(bday_str, "%Y%m%d").date()
+                    has_year = True
+                # Handle YYYY-MM-DD
+                elif len(bday_str) >= 10:
                     bday_date_part = bday_str.split('T')[0]
                     bday = datetime.strptime(bday_date_part, "%Y-%m-%d").date()
                     has_year = True


### PR DESCRIPTION
This PR extends the date parsing logic in both CardDavBirthdaySensor and CardDavNextBirthdaySensor classes to recognize and parse 8-digit birthday strings without dashes. Changes

Added a new condition to check for exactly 8 numeric characters Parse using datetime.strptime(bday_str, "%Y%m%d") for this format Placed this check before existing format checks to maintain backward compatibility Applied the same logic to both sensor classes consistently

Supported formats after this change

YYYYMMDD (e.g., 20010803) - NEW
YYYY-MM-DD (e.g., 2001-08-03) - existing
--MM-DD (e.g., --08-03) - existing (no year)

Testing
Tested with Synology CardDAV server providing dates in YYYYMMDD format. Sensors now correctly display birthday dates and calculate age/days until birthday. Backward Compatibility
Fully backward compatible - all existing date formats continue to work as before. The new format check is simply added as an additional option in the if-elif chain.